### PR TITLE
Update murmurhash3 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 version = "dev"
-install_requires = ["bitarray==1.6.1", "murmurhash3==2.3.5"]
+install_requires = ["bitarray==1.6.1", "mmh3==2.5.1"]
 extras_require = {}
 
 setup(


### PR DESCRIPTION
Keep murmurhash3 library up to date to fix deprecate warnings on Python 3.8+
```
<stdin>:1: DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
```